### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "build",
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fathyb/commitlint-circle"
+  },
   "scripts": {
     "build": "tsc",
     "commitmsg": "commitlint -E GIT_PARAMS"


### PR DESCRIPTION
This makes the https://www.npmjs.com/package/commitlint-circle page to display link to the source code repository.